### PR TITLE
Ubuntu xm-nuser-fix

### DIFF
--- a/medm/Makefile
+++ b/medm/Makefile
@@ -170,9 +170,9 @@ USR_LIBS_solaris = Xm12 Xt Xmu X11 Xext
 Xm12_DIR = $(MOTIF_LIB)
 endif
 
-USR_LIBS_Linux = Xm Xt Xp Xmu X11 Xext
+#USR_LIBS_Linux = Xm Xt Xp Xmu X11 Xext
 #Xp is not available and not needed on Linux Mint 18 
-#USR_LIBS_Linux = Xm Xt Xmu X11 Xext
+USR_LIBS_Linux = Xm Xt Xmu X11 Xext
 
 USR_LIBS_cygwin32 = Xm Xt Xmu X11 Xext SM ICE
 USR_LIBS_Darwin = -nil-

--- a/medm/Makefile
+++ b/medm/Makefile
@@ -170,9 +170,9 @@ USR_LIBS_solaris = Xm12 Xt Xmu X11 Xext
 Xm12_DIR = $(MOTIF_LIB)
 endif
 
-#USR_LIBS_Linux = Xm Xt Xp Xmu X11 Xext
+USR_LIBS_Linux = Xm Xt Xp Xmu X11 Xext
 #Xp is not available and not needed on Linux Mint 18 
-USR_LIBS_Linux = Xm Xt Xmu X11 Xext
+#USR_LIBS_Linux = Xm Xt Xmu X11 Xext
 
 USR_LIBS_cygwin32 = Xm Xt Xmu X11 Xext SM ICE
 USR_LIBS_Darwin = -nil-

--- a/medm/dialogs.c
+++ b/medm/dialogs.c
@@ -54,6 +54,7 @@
 #include <process.h>
 #endif
 #include <string.h>
+#include <stdint.h>
 #include <time.h>
 #include <ctype.h>
 #include <X11/IntrinsicP.h>
@@ -801,6 +802,8 @@ static void createPvLimitsDlg(void)
 static void pvLimitsDialogCallback(Widget w, XtPointer cd , XtPointer cbs)
 {
     int type = (intptr_t)cd;
+    uintptr_t userData;
+
     int button=0, src;
     double val;
     short sval;
@@ -839,7 +842,8 @@ static void pvLimitsDialogCallback(Widget w, XtPointer cd , XtPointer cbs)
    *   Find the real type from the userData of the RC parent of the button */
     if(type < 3) {
 	button=type;
-	XtVaGetValues(XtParent(w), XmNuserData, &type,NULL);
+	XtVaGetValues(XtParent(w), XmNuserData, &userData,NULL);
+	type=(int)userData;
 #if DEBUG_PVLIMITS
 	print("  Type is really %d, button is %d\n",type,button);
 #endif
@@ -1963,6 +1967,7 @@ static void updatePrintSetupFromDialog()
 static void printSetupDialogCallback(Widget w, XtPointer cd, XtPointer cbs)
 {
     int type = (intptr_t)cd;
+    uintptr_t userData;
     //int button;
 
   /* If the type is less than 4, the callback comes from an option
@@ -1970,7 +1975,8 @@ static void printSetupDialogCallback(Widget w, XtPointer cd, XtPointer cbs)
    *   parent of the button */
     if(type < 4) {
         //button=type;
-	XtVaGetValues(XtParent(w), XmNuserData, &type, NULL);
+	XtVaGetValues(XtParent(w), XmNuserData, &userData, NULL);
+	type = (int) userData;
     }
 
     switch(type) {

--- a/medm/resourcePalette.c
+++ b/medm/resourcePalette.c
@@ -198,7 +198,7 @@ static void optionMenuSimpleCallback(Widget w, XtPointer cd, XtPointer cbs)
 
   /****** rcType (which option menu) is stored in userData */
     XtVaGetValues(XtParent(w),XmNuserData,&userData,NULL);
-    rcType=(int)userData;
+    rcType=(long)userData;
     switch(rcType) {
     case ALIGN_RC:
 	globalResourceBundle.align = (TextAlign)(FIRST_TEXT_ALIGN + buttonId);

--- a/medm/resourcePalette.c
+++ b/medm/resourcePalette.c
@@ -27,6 +27,7 @@
 #define DEBUG_RELATED_DISPLAY 0
 
 #include <ctype.h>
+#include <stdint.h>
 #include "medm.h"
 #include <Xm/MwmUtil.h>
 #ifndef MEDM_CDEV
@@ -190,12 +191,14 @@ static void optionMenuSimpleCallback(Widget w, XtPointer cd, XtPointer cbs)
     DisplayInfo *cdi = currentDisplayInfo;
     int buttonId = (intptr_t)cd;
     long rcType;
+    uintptr_t userData;
     DlElement *elementPtr;
 
     UNREFERENCED(cbs);
 
   /****** rcType (which option menu) is stored in userData */
-    XtVaGetValues(XtParent(w),XmNuserData,&rcType,NULL);
+    XtVaGetValues(XtParent(w),XmNuserData,&userData,NULL);
+    rcType=(int)userData;
     switch(rcType) {
     case ALIGN_RC:
 	globalResourceBundle.align = (TextAlign)(FIRST_TEXT_ALIGN + buttonId);


### PR DESCRIPTION
On Ubuntu 16.04, 64 bit:

When calling XtVaGetValues() to retrieve the XmNuserData field, the returned value is of whatever size an XtPointer is. 

Passing the address of an int variable into this routine caused segfault, as the compiler treats an int as 32 bits, not the 64 bits XtVaGetValues is expecting.

Fixed by passing in a generic pointer type and casting to an int after the call.