### PR TITLE
Fix issue caused by using sprintf for overlapping buffer read/write

### DIFF
--- a/medm/dialogs.c
+++ b/medm/dialogs.c
@@ -1245,7 +1245,7 @@ void refreshDisplayListDlg(void)
 	      strlen(di->nameValueTable[i].name) +
 	      strlen(di->nameValueTable[i].value) + 2;
 	    if(len >= MAX_LENGTH) break;
-	    sprintf(string,"%s %s=%s", string,
+	    snprintf(string + strlen(string), sizeof(string) - strlen(string), " %s=%s",
 	      di->nameValueTable[i].name,  di->nameValueTable[i].value);
 	}
 	xmString = XmStringCreateLocalized(string);

--- a/medm/medm.c
+++ b/medm/medm.c
@@ -1714,7 +1714,7 @@ void mainFileMenuSimpleCallback(Widget w, XtPointer cd, XtPointer cbs)
               /* Prompt if All has not been choosen */
               if (!saveAll)
                 {
-                  sprintf(str, "Save \"%s\" ?", displayInfo->dlFile->name);
+                  snprintf(str, sizeof(str), "Save \"%s\" ?", displayInfo->dlFile->name);
                   dmSetAndPopupQuestionDialog(displayInfo, str, "Yes", "No",
                                               "All Remaining");
                   switch (displayInfo->questionDialogAnswer)
@@ -2157,7 +2157,7 @@ void medmExit()
                     filename = tmp + 1;
                   tmp++;
                 }
-              sprintf(str, "Save display \"%s\" before exit?", filename);
+              snprintf(str, sizeof(str), "Save display \"%s\" before exit?", filename);
 #ifdef PROMPT_TO_EXIT
               /* Don't use Cancel, use All (Only 3 buttons) */
               if (displayInfo->next)

--- a/medm/medmRelatedDisplay.c
+++ b/medm/medmRelatedDisplay.c
@@ -863,7 +863,7 @@ static void relatedDisplayButtonPressedCb(Widget w, XtPointer clientData,
 /* code copied from wmctrl to move window to the current desktop */
 #define MAX_PROPERTY_VALUE_LEN 4096
 
-static char *get_property (Display *disp, Window win, 
+static char *get_property (Display *disp, Window win,
         Atom xa_prop_type, char *prop_name, unsigned long *size) {
     Atom xa_prop_name;
     Atom xa_ret_type;
@@ -873,20 +873,20 @@ static char *get_property (Display *disp, Window win,
     unsigned long tmp_size;
     unsigned char *ret_prop;
     char *ret;
-    
+
     xa_prop_name = XInternAtom(disp, prop_name, False);
-    
+
     /* MAX_PROPERTY_VALUE_LEN / 4 explanation (XGetWindowProperty manpage):
      *
      * long_length = Specifies the length in 32-bit multiples of the
      *               data to be retrieved.
      */
     if (XGetWindowProperty(disp, win, xa_prop_name, 0, MAX_PROPERTY_VALUE_LEN / 4, False,
-            xa_prop_type, &xa_ret_type, &ret_format,     
+            xa_prop_type, &xa_ret_type, &ret_format,
             &ret_nitems, &ret_bytes_after, &ret_prop) != Success) {
         return NULL;
     }
-  
+
     if (xa_ret_type != xa_prop_type) {
         XFree(ret_prop);
         return NULL;
@@ -901,13 +901,13 @@ static char *get_property (Display *disp, Window win,
     if (size) {
         *size = tmp_size;
     }
-    
+
     XFree(ret_prop);
     return ret;
 }
 
 static int client_msg(Display *disp, Window win, char *msg,
-    unsigned long data0, unsigned long data1, 
+    unsigned long data0, unsigned long data1,
     unsigned long data2, unsigned long data3,
     unsigned long data4) {
   XEvent event;
@@ -1014,7 +1014,7 @@ void relatedDisplayCreateNewDisplay(DisplayInfo *displayInfo,
          passing the parent's path. */
 	filePtr = dmOpenUsableFile(filename, displayInfo->dlFile->name);
 	if(filePtr == NULL) {
-	    sprintf(token,
+	    snprintf(token, sizeof(token),
 	      "Cannot open related display:\n  %s\nCheck %s\n",
 	      filename, "EPICS_DISPLAY_PATH");
 	    dmSetAndPopupWarningDialog(displayInfo,token,"OK",NULL,NULL);

--- a/printUtils/utilPrint.c
+++ b/printUtils/utilPrint.c
@@ -156,7 +156,7 @@ int utilPrint(Display *display, Widget w, char *xwdFileName, char *title)
 	break;
     case PRINT_TITLE_SPECIFIED:
 	if(*printTitleString) {
-	    sprintf(titleString,"-s%s", printTitleString);
+	    snprintf(titleString, sizeof(titleString), "-s%s", printTitleString);
 	    myArgv[myArgc++] = titleString;
 	}
 	break;
@@ -194,7 +194,7 @@ int utilPrint(Display *display, Widget w, char *xwdFileName, char *title)
     } else {
       /* Print the file to the printer, unless you are debugging, in
          which case you can look at the files instead */
-	sprintf(commandBuffer, "%s %s", printCommand, psFileName);
+	snprintf(commandBuffer, sizeof(commandBuffer), "%s %s", printCommand, psFileName);
 	status=system(commandBuffer);
 #ifndef VMS
 	if(status) {

--- a/xc/WheelSwitch.c
+++ b/xc/WheelSwitch.c
@@ -1411,8 +1411,9 @@ static void compute_format(WswWidget wsw)
     while(!isdigit(kbd_format_buffer[j++]=format_used[i++])) ;
     while(format_used[i++]!='f') ;
     kbd_format_buffer[j-1]='\0';
-    sprintf(kbd_format_buffer,"%s%ds%s",
-      kbd_format_buffer,
+    snprintf(kbd_format_buffer + strlen(kbd_format_buffer),
+     sizeof(kbd_format_buffer) - strlen(kbd_format_buffer),
+     "%ds%s",
       wsw->wsw.digit_size,
       format_used+i);
     replace_string(&wsw->wsw.kbd_format, kbd_format_buffer, WS_FREE);


### PR DESCRIPTION
### Description
Replaced sprintf with snprintf to avoid undefined behavior. The issue was due to sprintf reading and writing to the same buffer, which can lead to undefined behavior. 
sprintf does not start at the end of the buffer but reads the original string while writing to it, causing potential memory overlap issues.

### Comparison of PV Info Screen
Below are the screenshots comparing the PV Info screen output when using `sprintf` vs. not using `sprintf`:

#### Using 'sprintf'
![Using sprintf](https://github.com/epics-extensions/medm/assets/51432966/927c9c69-ba25-4672-80f2-5f12aa6b7c61)

#### Using 'snprintf'
![Not using sprintf](https://github.com/epics-extensions/medm/assets/51432966/76717888-12cd-464b-aff5-879d6b103447)

### Test Environment
- **Operating System** : Ubuntu 24.04

### Changes
- Replaced `sprintf` with `snprintf` to avoid undefined behavior.
- Updated the code to ensure safe string concatenation and buffer management.
