### PR TITLE
Added workaround to library woes on linux

### DIFF
--- a/medm/Makefile
+++ b/medm/Makefile
@@ -177,6 +177,16 @@ endif
 USR_LIBS_Linux = Xm Xt Xp Xmu X11 Xext
 #Xp is not available and not needed on Linux Mint 18 
 #USR_LIBS_Linux = Xm Xt Xmu X11 Xext
+ 
+# If you encounter No rule to make target '../../../../lib/linux-x86_64/libXm.a
+# despite MOTIF_DIR being set correctly, try enabling the following by by setting
+# MEDM_NOLIBS=YES in CONFIG_SITE:
+
+ifeq ($(MEDM_NOLIBS),YES)
+USR_LIBS_DEFAULT=
+USR_LIBS_Linux = 
+USR_LDFLAGS=-lXm -lXt -lXmu -lX11 -lXext
+endif
 
 USR_LIBS_cygwin32 = Xm Xt Xmu X11 Xext SM ICE
 USR_LIBS_Darwin = -nil-


### PR DESCRIPTION
I got the error 

`` No rule to make target '../../../../lib/linux-x86_64/libXm.a ``

I quickly found that previous generations had already [encountered](https://epics.anl.gov/tech-talk/2013/msg00320.php) this. 
So I set ``MOTIF_LIB`` and ``X11_LIB`` correctly.

Unfortunately, this did not change a thing. 

Rather than following into the rabbit hole of debugging whatever byzantine makefile construct is supposed to parse ``Xm_DIR`` and create a dependency from it[^cmake], I decided to cut the chase and just tell the linker what to link against, bypassing the epics library mechanism. Given that these are system libraries, I think I can live without make checking if they are up to date or should be recompiled. (Also, I linked dynamically, whatever.)

I thought that some other linux users might appreciate this shortcut as well. In my opinion, the inclusion of ``Xp`` (which is a library not included in most Linux distributions released after 2016) in ``USR_LIBS_Linux`` per default in the Makefile already provides for a sufficient hazing ritual for newbies like me. 

[^cmake]: I am not a big fan of CMake, whose syntax I find ugly. But after my experiences today, I will concede that having a configuration tool with a scope of more than one software project is definitely a good thing.