### PR TITLE
fix that bubbleHelp widget steals focus

### DIFF
--- a/medm/bubbleHelp.c
+++ b/medm/bubbleHelp.c
@@ -90,6 +90,7 @@ static void makeBubbleHelpWidget(Widget w, char *label)
     nargs=0;
     XtSetArg(args[nargs],XmNmwmDecorations,0); nargs++;
     XtSetArg(args[nargs],XmNmwmFunctions,0); nargs++;
+    XtSetArg(args[nargs],XmNinput,False); nargs++;
     XtSetArg(args[nargs],XmNx,x+width/2+BUBBLE_DELTAX); nargs++;
     XtSetArg(args[nargs],XmNy,y+height+BUBBLE_DELTAY); nargs++;
     bubbleHelpWidget=XmCreateDialogShell(wparent,"bubbleHelpD",args,nargs);


### PR DESCRIPTION
Currently the bubbleHelp widget continuously steals the focus of the widget it attaches. e.g. on the "Object Palette", the buttons cannot be selected because of losing focus. 